### PR TITLE
Naming bugfix

### DIFF
--- a/operate/models/apis.py
+++ b/operate/models/apis.py
@@ -559,7 +559,7 @@ def call_ollama(model, messages):
         print(f"[call_ollama] model {model}")
     time.sleep(1)
     try:
-        model = config.initialize_ollama()
+        ollama_model = config.initialize_ollama()
         screenshots_dir = "screenshots"
         if not os.path.exists(screenshots_dir):
             os.makedirs(screenshots_dir)
@@ -586,7 +586,7 @@ def call_ollama(model, messages):
         }
         messages.append(vision_message)
 
-        response = ollama.chat(
+        response = ollama_model.chat(
             model=model,
             messages=messages,
         )


### PR DESCRIPTION
Hey there,
Thank you for adding a great feature.
Here is a quick bugfix.
In call_ollama function, ollama was created in "ollama" variable, which is also the same as the package which is imported.
Skipping that, "ollama" should have been called for inference, instead of the "model" variable which was supposed to have the model name.
I've tested it and it works now.
Thanks.